### PR TITLE
Quit game from the pause menu

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -805,7 +805,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1484096894}
         m_TargetAssemblyTypeName: PauseMenu, Scripts
-        m_MethodName: GoToMainMenu
+        m_MethodName: Quit
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -12438,7 +12438,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 640883564086290064, guid: 2ca2f5e6bb4011749b8779c842dc583d, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 640883564086290064, guid: 2ca2f5e6bb4011749b8779c842dc583d, type: 3}
       propertyPath: m_AnchorMax.x
@@ -13145,7 +13145,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7949240159095395301, guid: 3dfda06e15a3f2e41b862565495a2e2a, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7949240159095395301, guid: 3dfda06e15a3f2e41b862565495a2e2a, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scripts/Controller/PauseMenu.cs
+++ b/Assets/Scripts/Controller/PauseMenu.cs
@@ -51,11 +51,11 @@ public class PauseMenu : MonoBehaviour
     }
 
     /// <summary>
-    /// Quit the game and go back to the main menu.
+    /// Quit the game.
     /// </summary>
-    public void GoToMainMenu()
+    public void Quit()
     {
-        SceneManager.LoadScene("Menu");
+        Application.Quit();
     }
 
     /// <summary>


### PR DESCRIPTION
This is only  a small change which affects the button "Quit Game" within the pause menu. The wished behavior after clicking on this button is that the main menu is loaded and by clicking on "Play" a new game is started. By reloading the main scene not all objects are resetted because of the not DontDestroy-property. That is why we decided to implement a workaround. The application just closes by clicking on "Quit Game" (same as "Quit" within the main menu).